### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=TM1638 button and LED controller library for Arduino
 paragraph=This is an optimized TM1638 LED driver controller with key-scan interface library for Arduino.
 category=Display
 url=https://github.com/Erriez/ErriezTM1638
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format